### PR TITLE
Update webpack rule to be compatible with webpack 4

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -25,7 +25,7 @@ function webpackLoader(source: string): void {
     const opts = {
         ...params,
         ...query,
-        ...this.options.configLoader || {}
+        ...(this.options && this.options.configLoader) || {}
     }
 
     const templateArgs = {


### PR DESCRIPTION
Global options are not available anymore in webpack 4

Tested with create-react-app + react-app-rewired and a custom rule 👍 